### PR TITLE
Add eta-mu GitHub workflows

### DIFF
--- a/.github/workflows/eta-mu-review-gate.yml
+++ b/.github/workflows/eta-mu-review-gate.yml
@@ -1,0 +1,50 @@
+name: eta-mu-review-gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  coderabbit-review-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+
+      - name: Checkout eta-mu logic
+        uses: actions/checkout@v4
+        with:
+          repository: open-hax/eta-mu-github
+          path: .eta-mu
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .eta-mu/pnpm-lock.yaml
+
+      - name: Install eta-mu dependencies
+        run: pnpm --dir .eta-mu install --frozen-lockfile
+
+      - name: Enforce review-thread resolution for configured actors
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
+        run: >-
+          pnpm --dir .eta-mu dev review-gate
+          --repo "${GITHUB_REPOSITORY}"
+          --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/eta-mu.yml
+++ b/.github/workflows/eta-mu.yml
@@ -1,0 +1,80 @@
+name: eta-mu
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: eta-mu-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  eta-mu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout eta-mu logic
+        uses: actions/checkout@v4
+        with:
+          repository: open-hax/eta-mu-github
+          path: .eta-mu
+
+      - name: Create eta-mu app token
+        id: eta_mu_token
+        if: ${{ secrets.ETA_MU_APP_ID != '' && secrets.ETA_MU_APP_PRIVATE_KEY != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ETA_MU_APP_ID }}
+          private-key: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: .eta-mu/pnpm-lock.yaml
+
+      - name: Install eta-mu dependencies
+        run: pnpm --dir .eta-mu install --frozen-lockfile
+
+      - name: Run eta-mu event handler
+        env:
+          GITHUB_TOKEN: ${{ steps.eta_mu_token.outputs.token != '' && steps.eta_mu_token.outputs.token || github.token }}
+          ETA_MU_APP_ID: ${{ secrets.ETA_MU_APP_ID }}
+          ETA_MU_APP_PRIVATE_KEY: ${{ secrets.ETA_MU_APP_PRIVATE_KEY }}
+          ETA_MU_MODEL_PROVIDER: ${{ vars.ETA_MU_MODEL_PROVIDER }}
+          ETA_MU_MODEL_ID: ${{ vars.ETA_MU_MODEL_ID }}
+          ETA_MU_REVIEW_ACTORS: ${{ vars.ETA_MU_REVIEW_ACTORS }}
+          ETA_MU_MENTION_TOKENS: ${{ vars.ETA_MU_MENTION_TOKENS }}
+          ETA_MU_IGNORE_LOGINS: ${{ vars.ETA_MU_IGNORE_LOGINS }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: >-
+          pnpm --dir .eta-mu dev run-event
+          --repo "${GITHUB_REPOSITORY}"
+          --event-name "${GITHUB_EVENT_NAME}"
+          --event-path "${GITHUB_EVENT_PATH}"
+          --cwd "$PWD"


### PR DESCRIPTION
## Summary
- add the shared `eta-mu` event workflow wrapper
- add the `eta-mu-review-gate` workflow so unresolved CodeRabbit review threads can become a required merge gate

## Notes
- intended required check context: `coderabbit-review-gate`
- intended branch protection still relies on native review-thread resolution as well
- rollout source: `riatzukiza/TANF-app` via devel automation